### PR TITLE
Gitpod default setup

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full
+FROM gitpod/workspace-python
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
     sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
+    sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg \
+    && sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list' \
+    && sudo apt-get update \
+    && sudo apt-get install azure-functions-core-tools-4

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,7 @@
 FROM gitpod/workspace-python
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
-    sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg \
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+RUN sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg \
     && sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list' \
     && sudo apt-get update \
-    && sudo apt-get install azure-functions-core-tools-4
+    && sudo apt-get install azure-functions-core-tools-4 -y

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+image:
+  file: .gitpod.Dockerfile

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Also, make sure you have installed the following:
 
 * [Visual Studio Code](https://code.visualstudio.com/download)
 * [Git](https://git-scm.com/)
-* [Azure Functions Core Tools version 3.x.](https://docs.microsoft.com/en-gb/azure/azure-functions/functions-run-local#v2)
+* [Azure Functions Core Tools version 4.x.](https://docs.microsoft.com/en-gb/azure/azure-functions/functions-run-local#v2)
   * The Function Tools are not required if you are following the alternative exercise
 * [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 * [Python](https://www.python.org/downloads/)

--- a/alternative_workshop_11.md
+++ b/alternative_workshop_11.md
@@ -19,6 +19,7 @@ We will host this application in a non-scalable way, which we can then perform *
 
 In the same folder as above:
  - Login to the Azure CLI: `az login`
+  - If you're using GitPod, you'll need to use `az login --use-device-code`
  - Create a Web App:
  ```
  az webapp up --sku B1 --location uksouth --name <APP_NAME> --resource-group <RG_NAME>

--- a/during_workshop_11.md
+++ b/during_workshop_11.md
@@ -19,6 +19,7 @@ We will host this application in a non-scalable way, which we can then perform *
 
 In the same folder as above:
  - Login to the Azure CLI: `az login`
+  - If you're using GitPod, you'll need to use `az login --use-device-code`
  - Create a Web App:
  ```
  az webapp up --sku B1 --location uksouth --name <APP_NAME> --resource-group <RG_NAME>

--- a/during_workshop_11.md
+++ b/during_workshop_11.md
@@ -235,7 +235,7 @@ az storage account create --name <STORAGE_NAME> --location uksouth --resource-gr
 - A _Function App_: This is the container for your function code within Azure, it can be thought of the Azure equivalent to your local function project.
 
 ```
-az functionapp create --resource-group <RG_NAME> --consumption-plan-location uksouth --runtime python --runtime-version 3.8 --functions-version 3 --name <APP_NAME> --storage-account <STORAGE_NAME> --os-type linux
+az functionapp create --resource-group <RG_NAME> --consumption-plan-location uksouth --runtime python --runtime-version 3.8 --functions-version 4 --name <APP_NAME> --storage-account <STORAGE_NAME> --os-type linux
 ```
 
 > `<STORAGE_NAME>` should be the name of the Storage Account you just created. Replace `<APP_NAME>` with a name that is unique across all of Azure (as this application will be hosted at `<APP_NAME>.azurewebsites.net`). For example you could use your initials plus today's date e.g. `abc-01-01-1900-functions`. It must also differ from the app name you used in Part 1. If you get a "usage error", check that the directory you are in (or any parent directory) doesn't already contain a `.azure/config` file.


### PR DESCRIPTION
Some default setup to make switching into GitPod easier, particularly for learners hitting issues installing the Azure CLI or the Function Tools. I checked that I can log into the Azure CLI, and initiate a new Function project without issue. The only difference after creating that I can see is `az login` requires using `--use-device-code` since the localhost redirect won't hit the GitPod VM, so I've updated the instructions for that