### PR TITLE
Reword bundle version checking as an explicit step

### DIFF
--- a/during_workshop.md
+++ b/during_workshop.md
@@ -299,7 +299,8 @@ It is worth checking out the [Table Storage output binding documentation](https:
 
 To run the function locally you will need to run the command `func azure functionapp fetch-app-settings <app_name>` to provide your local instance with the correct connection details.
 
-You will also need to ensure that the [Extension Bundle](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-register#extension-bundles) version in _host.json_ is set to `"version": "[2.*, 3.0.0)"`, since later versions (3.* and 4.*) are incompatible with Table Storage at the time of writing.
+__You will also need to ensure that the [Extension Bundle](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-register#extension-bundles) version in _host.json_ is set to `"version": "[2.*, 3.0.0)"`, since later versions (3.* and 4.*) are incompatible with Table Storage at the time of writing.__
+
 
 Run the function locally with `func start` before trying to publish it. This way you get faster feedback and can see error messages in your terminal. Once you are happy it works you can publish it.
 

--- a/during_workshop.md
+++ b/during_workshop.md
@@ -299,11 +299,11 @@ It is worth checking out the [Table Storage output binding documentation](https:
 
 To run the function locally you will need to run the command `func azure functionapp fetch-app-settings <app_name>` to provide your local instance with the correct connection details.
 
+You will also need to ensure that the [Extension Bundle](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-register#extension-bundles) version in _host.json_ is set to `"version": "[2.*, 3.0.0)"`, since later versions (3.* and 4.*) are incompatible with Table Storage at the time of writing.
+
 Run the function locally with `func start` before trying to publish it. This way you get faster feedback and can see error messages in your terminal. Once you are happy it works you can publish it.
 
 You can check whether you have been successful by using the Azure Portal to see if your function is adding data to the Azure Table.
-
-> To use table storage you need the correct version of the [Extensions Bundle](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-register#extension-bundles). At the time of writing you will need to use version 2 of the extensions bundle (you can set the version in the `host.json` file).
 
 ## Part 4 - Communicating between functions
 


### PR DESCRIPTION
Thank you Microsoft for removing the information that this is still broken on 3.x and 4.x versions. ([MS Docs](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-register#extension-bundles))

![image](https://user-images.githubusercontent.com/44811850/220388766-038ed14a-0739-45bb-859a-a96e09c7b758.png)
